### PR TITLE
modify eslint setting

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -2,6 +2,8 @@ import nextPlugin from '@next/eslint-plugin-next'
 import js from '@eslint/js'
 import tseslint from 'typescript-eslint'
 import eslintConfigPrettier from 'eslint-config-prettier'
+import reactPlugin from 'eslint-plugin-react'
+import hooksPlugin from 'eslint-plugin-react-hooks'
 
 const config = [
   {
@@ -45,13 +47,23 @@ const config = [
   },
   ...tseslint.configs.recommended,
   {
-    files: ['**/*.ts', '**/*.tsx'],
-    languageOptions: {
-      parser: tseslint.parser,
-      parserOptions: {
-        project: './tsconfig.json',
+    name: 'react/jsx-runtime',
+    plugins: {
+      react: reactPlugin,
+    },
+    rules: reactPlugin.configs['jsx-runtime'].rules,
+    settings: {
+      react: {
+        version: 'detect',
       },
     },
+  },
+  {
+    name: 'react-hooks/recommended',
+    plugins: {
+      'react-hooks': hooksPlugin,
+    },
+    rules: hooksPlugin.configs.recommended.rules,
   },
   {
     name: 'next/core-web-vitals',

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "start": "next start",
     "lint": "eslint \"**/*.{js,jsx,ts,tsx}\"",
     "format": "prettier --write .",
-    "inspect": "npx eslint --inspect-config",
+    "inspect": "eslint --inspect-config",
     "prepare": "husky"
   },
   "lint-staged": {

--- a/package.json
+++ b/package.json
@@ -34,6 +34,8 @@
     "eslint": "^9.14.0",
     "eslint-config-next": "15.0.3",
     "eslint-config-prettier": "^9.1.0",
+    "eslint-plugin-react": "^7.37.2",
+    "eslint-plugin-react-hooks": "^5.0.0",
     "husky": "^9.1.6",
     "lint-staged": "^15.2.10",
     "postcss": "^8.4.47",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -48,6 +48,12 @@ importers:
       eslint-config-prettier:
         specifier: ^9.1.0
         version: 9.1.0(eslint@9.14.0(jiti@1.21.6))
+      eslint-plugin-react:
+        specifier: ^7.37.2
+        version: 7.37.2(eslint@9.14.0(jiti@1.21.6))
+      eslint-plugin-react-hooks:
+        specifier: ^5.0.0
+        version: 5.0.0(eslint@9.14.0(jiti@1.21.6))
       husky:
         specifier: ^9.1.6
         version: 9.1.6


### PR DESCRIPTION
The @next/eslint-plugin-next package contains the eslint-plugin-react package and the eslint-plugin-react-hooks package, but only includes the recommended options. 
so modify it to override the recommended options but otherwise follow the options