### PR TITLE
Document template deployment and complete API tasks

### DIFF
--- a/README.ko.md
+++ b/README.ko.md
@@ -1,0 +1,86 @@
+# monorepo-template
+
+[English](README.md) | [한국어](README.ko.md)
+
+Next.js 프론트엔드와 Hono API로 구성한 TypeScript 모노레포
+템플릿입니다. pnpm workspace와 Turborepo로 관리합니다.
+
+## 구성
+
+| 영역        | 경로         | 기술                                           |
+| ----------- | ------------ | ---------------------------------------------- |
+| 웹          | `apps/web`   | Next.js, React, StyleX, TanStack Query, XState |
+| API         | `apps/api`   | Hono, Node.js                                  |
+| 도구        | workspace    | Turborepo, TypeScript, oxfmt, oxlint           |
+| 테스트      | `apps/web`   | Vitest, Playwright                             |
+| 공통 패키지 | `packages/*` | 애플리케이션에서 공유할 코드를 위한 경로       |
+
+## 요구사항
+
+- Node.js 24 LTS (`24.18.0` 이상인 24.x 버전)
+- pnpm `11.15.1`
+
+## 시작하기
+
+```bash
+pnpm install
+pnpm dev
+```
+
+하나의 애플리케이션만 실행하려면 패키지 필터를 사용합니다.
+
+```bash
+pnpm --filter @repo/web dev
+pnpm --filter api dev
+```
+
+## 명령어
+
+| 명령어               | 용도                                     |
+| -------------------- | ---------------------------------------- |
+| `pnpm build`         | 모든 애플리케이션 빌드                   |
+| `pnpm format`        | workspace 파일 포맷                      |
+| `pnpm format:check`  | 포맷 검사                                |
+| `pnpm lint`          | 엄격한 타입 인식 린트 실행               |
+| `pnpm lint:fix`      | 자동 수정 가능한 린트 오류 수정          |
+| `pnpm typecheck`     | 모든 애플리케이션 타입 검사              |
+| `pnpm test`          | 테스트 한 번 실행                        |
+| `pnpm test:watch`    | 테스트 watch 모드 실행                   |
+| `pnpm test:coverage` | 커버리지 보고서 생성                     |
+| `pnpm test:e2e`      | Playwright 테스트를 headless 모드로 실행 |
+| `pnpm test:e2e:ui`   | Playwright UI 실행                       |
+
+브라우저 테스트를 실행하기 전에 Chromium을 한 번 설치합니다.
+
+```bash
+pnpm --filter @repo/web exec playwright install chromium
+```
+
+## 규칙
+
+- [프론트엔드 상태 및 데이터 흐름](docs/frontend/state-management.md)에서
+  XState와 TanStack Query의 책임 경계를 정의합니다.
+- 린트는 엄격한 타입 인식 검사를 수행하며 경고가 발생해도 실패합니다.
+
+## 권장 배포 구성
+
+이 템플릿으로 만든 프로젝트는 보통 다음 프로덕션 서비스를 사용합니다.
+아래 서비스는 권장 사항이며 템플릿에 미리 설정되어 있지 않습니다.
+
+| 영역              | 서비스              | 용도                                           |
+| ----------------- | ------------------- | ---------------------------------------------- |
+| 프론트엔드        | Cloudflare Workers  | OpenNext를 통한 Next.js 애플리케이션 배포      |
+| 백엔드            | Railway             | Hono API를 지속 실행되는 Node.js 서비스로 운영 |
+| 데이터베이스      | Railway PostgreSQL  | 트랜잭션 애플리케이션 데이터 저장              |
+| 오브젝트 스토리지 | Cloudflare R2       | 업로드 파일과 오브젝트 저장                    |
+| 오류 모니터링     | Sentry              | 프론트엔드와 백엔드 오류 수집                  |
+| 업타임 및 알림    | Better Stack        | 공개 웹과 API 헬스 체크 감시                   |
+| 메트릭            | Railway 기본 메트릭 | 초기 프로덕션 리소스 사용량 확인               |
+
+다음 서비스는 프로젝트에 필요한 경우에만 추가합니다.
+
+| 필요한 기능                               | 서비스           |
+| ----------------------------------------- | ---------------- |
+| 공유 캐시, 요청 제한, 잠금 또는 세션      | Upstash Redis    |
+| Prometheus 호환 메트릭과 Grafana 대시보드 | Grafana Cloud    |
+| 대용량 이벤트, 로그 또는 제품 분석        | ClickHouse Cloud |

--- a/README.md
+++ b/README.md
@@ -1,71 +1,87 @@
 # monorepo-template
 
-This repository is a pnpm workspace monorepo orchestrated by Turborepo.
+[English](README.md) | [한국어](README.ko.md)
 
-## Structure
+An opinionated TypeScript monorepo template with a Next.js frontend and a Hono
+API, managed with pnpm workspaces and Turborepo.
 
-- `apps/web` is the Next.js application.
-- `packages/*` is reserved for shared packages.
+## Included
 
-## Frontend conventions
-
-- [State and data flow](docs/frontend/state-management.md) explains the
-  XState and TanStack Query ownership boundaries.
+| Area            | Path         | Stack                                          |
+| --------------- | ------------ | ---------------------------------------------- |
+| Web             | `apps/web`   | Next.js, React, StyleX, TanStack Query, XState |
+| API             | `apps/api`   | Hono, Node.js                                  |
+| Tooling         | Workspace    | Turborepo, TypeScript, oxfmt, oxlint           |
+| Tests           | `apps/web`   | Vitest, Playwright                             |
+| Shared packages | `packages/*` | Reserved for code shared across applications   |
 
 ## Requirements
 
 - Node.js 24 LTS (`24.18.0` or newer within the 24.x line)
 - pnpm `11.15.1`
 
-## Commands
-
-Run these from the repository root:
+## Getting started
 
 ```bash
 pnpm install
 pnpm dev
-pnpm build
-pnpm format
-pnpm format:check
-pnpm lint
-pnpm lint:fix
-pnpm test
-pnpm test:coverage
-pnpm test:e2e
-pnpm test:e2e:ui
-pnpm test:watch
-pnpm typecheck
-pnpm start
 ```
 
-Root commands run through Turbo. `lint` is strict, type-aware, and type-checks;
-warnings fail the command. Build, type-check, test, and coverage results use the
-local task cache; `format:check` and `lint` may cache their logs. The mutating
-`format` and `lint:fix` tasks and the persistent `dev`, `start`, and `test:watch`
-tasks are not cached. Browser E2E tasks are also not cached. No remote cache is
-configured.
+Run a task for one application with a package filter:
 
-Unit and integration tests use Vitest's Node environment. Keep unit tests next
-to their source as `*.test.ts` or `*.test.tsx`, and put integration tests under
-`apps/web/tests/integration` as `*.integration.test.ts` or
-`*.integration.test.tsx`. `test` runs once, `test:watch` stays open for local
-development, and `test:coverage` writes V8 coverage reports under each
-package's ignored `coverage` directory.
+```bash
+pnpm --filter @repo/web dev
+pnpm --filter api dev
+```
 
-Browser E2E tests use Playwright with Chromium and live under `apps/web/e2e`.
-Install its browser once after installing dependencies:
+## Commands
+
+| Command              | Purpose                         |
+| -------------------- | ------------------------------- |
+| `pnpm build`         | Build all applications          |
+| `pnpm format`        | Format workspace files          |
+| `pnpm format:check`  | Check formatting                |
+| `pnpm lint`          | Run strict, type-aware linting  |
+| `pnpm lint:fix`      | Fix supported lint violations   |
+| `pnpm typecheck`     | Type-check all applications     |
+| `pnpm test`          | Run tests once                  |
+| `pnpm test:watch`    | Run tests in watch mode         |
+| `pnpm test:coverage` | Generate coverage reports       |
+| `pnpm test:e2e`      | Run Playwright tests headlessly |
+| `pnpm test:e2e:ui`   | Open Playwright UI              |
+
+Install Chromium once before running the browser tests:
 
 ```bash
 pnpm --filter @repo/web exec playwright install chromium
 ```
 
-`test:e2e` builds the production app and runs headlessly, while `test:e2e:ui`
-builds the app and opens Playwright UI.
+## Conventions
 
-For direct application commands, use the package escape hatch:
+- [Frontend state and data flow](docs/frontend/state-management.md) defines the
+  XState and TanStack Query ownership boundaries.
+- Linting is strict and type-aware. Warnings fail the command.
 
-```bash
-pnpm --filter @repo/web dev
-```
+## Recommended deployment
 
-The main page is at `apps/web/src/app/page.tsx`.
+A typical production deployment for a project created from this template uses
+the following services. The providers are recommendations and are not
+preconfigured by the template.
+
+| Area              | Service                  | Use                                              |
+| ----------------- | ------------------------ | ------------------------------------------------ |
+| Frontend          | Cloudflare Workers       | Deploy the Next.js application through OpenNext  |
+| Backend           | Railway                  | Run the Hono API as a persistent Node.js service |
+| Database          | Railway PostgreSQL       | Store transactional application data             |
+| Object storage    | Cloudflare R2            | Store uploaded files and other objects           |
+| Error monitoring  | Sentry                   | Collect frontend and backend errors              |
+| Uptime and alerts | Better Stack             | Monitor public web and API health checks         |
+| Metrics           | Railway built-in metrics | Monitor initial production resource usage        |
+
+Add these services only when the project needs them:
+
+| Need                                                 | Service          |
+| ---------------------------------------------------- | ---------------- |
+| Shared cache, rate limiting, locks, or sessions      | Upstash Redis    |
+| Prometheus-compatible metrics and Grafana dashboards | Grafana Cloud    |
+| High-volume event, log, or product analytics         | ClickHouse Cloud |

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -8,7 +8,8 @@
     "format:check": "oxfmt --check",
     "lint": "oxlint .",
     "lint:fix": "oxlint . --fix",
-    "start": "node dist/index.js"
+    "start": "node dist/index.js",
+    "typecheck": "tsc --noEmit"
   },
   "dependencies": {
     "@hono/node-server": "^2.0.12",

--- a/turbo.json
+++ b/turbo.json
@@ -3,7 +3,7 @@
   "tasks": {
     "build": {
       "dependsOn": ["^build"],
-      "outputs": [".next/**", "!.next/cache/**"]
+      "outputs": [".next/**", "!.next/cache/**", "dist/**"]
     },
     "dev": {
       "cache": false,


### PR DESCRIPTION
## Summary

- rewrite the English README and add a synchronized Korean README
- document the template stack, setup commands, recommended deployment services, and optional infrastructure
- add the API to the workspace type-check task
- cache and restore the API `dist/**` build output through Turbo

## Why

The README described the repository narrowly and presented infrastructure as a project-specific assumption instead of guidance for projects created from the template. The API also lacked a `typecheck` script, so the root type-check skipped it, and Turbo did not declare its compiled output.

## Impact

Users get concise onboarding and deployment guidance in English and Korean. Workspace type-checking now covers both applications, and cached API builds preserve their compiled output.

## Validation

- `pnpm typecheck` — 2/2 tasks passed
- `pnpm test` — 5/5 tests passed
- `pnpm lint` — 0 warnings and 0 errors
- `pnpm format:check`
- `pnpm build` — web and API builds passed
- targeted `oxfmt --check` and `git diff --check`

Local commands emitted the expected engine warning because the active runtime is Node.js `24.14.0`; the repository requires Node.js `24.18.0` or newer within the 24.x line.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a Korean README with setup instructions, workspace guidance, scripts, testing requirements, and deployment recommendations.
  * Reworked the English README with language links, simplified setup and command references, project conventions, and deployment options.

* **Developer Experience**
  * Added an API type-checking command.
  * Improved build artifact tracking for API and frontend outputs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->