### PR TITLE
build: strengthen oxlint policy enforcement

### DIFF
--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -1,6 +1,6 @@
 {
   "$schema": "./node_modules/oxlint/configuration_schema.json",
-  "plugins": ["eslint", "import", "node", "oxc", "promise", "typescript", "unicorn"],
+  "plugins": ["import", "node", "oxc", "promise", "typescript", "unicorn"],
   "options": {
     "denyWarnings": true,
     "reportUnusedDisableDirectives": "error",
@@ -8,11 +8,14 @@
     "typeCheck": true
   },
   "rules": {
+    "typescript/no-confusing-non-null-assertion": "off",
     "typescript/no-empty-object-type": "error",
     "typescript/no-explicit-any": "error",
+    "typescript/no-extra-non-null-assertion": "off",
     "typescript/no-import-type-side-effects": "error",
     "typescript/no-invalid-void-type": "error",
-    "typescript/no-non-null-asserted-nullish-coalescing": "error",
+    "typescript/no-non-null-asserted-nullish-coalescing": "off",
+    "typescript/no-non-null-asserted-optional-chain": "off",
     "typescript/no-non-null-assertion": "error",
     "typescript/no-require-imports": "error",
     "typescript/use-unknown-in-catch-callback-variable": "error",
@@ -21,6 +24,9 @@
     "oxc/no-accumulating-spread": "error",
     "unicorn/no-abusive-eslint-disable": "error",
     "unicorn/no-useless-error-capture-stack-trace": "error",
-    "unicorn/no-array-sort": ["error", { "allowAfterSpread": true }]
+    "unicorn/no-array-sort": [
+      "error",
+      { "allowAfterSpread": true, "allowExpressionStatement": false }
+    ]
   }
 }

--- a/apps/api/.oxlintrc.json
+++ b/apps/api/.oxlintrc.json
@@ -13,6 +13,7 @@
   },
   "ignorePatterns": [".turbo/**", "coverage/**", "dist/**", "node_modules/**", "*.tsbuildinfo"],
   "rules": {
+    "eslint/complexity": ["error", { "max": 20, "variant": "classic" }],
     "eslint/max-lines-per-function": [
       "error",
       {
@@ -94,20 +95,21 @@
       "error",
       {
         "checksConditionals": true,
-        "checksSpreads": true,
+        "checksSpreads": false,
         "checksVoidReturn": false
       }
     ],
+    "typescript/strict-void-return": ["error", { "allowReturnAny": false }],
     "typescript/no-unnecessary-condition": [
       "error",
       {
-        "checkTypePredicates": true
+        "checkTypePredicates": false
       }
     ],
     "typescript/switch-exhaustiveness-check": [
       "error",
       {
-        "allowDefaultCaseForExhaustiveSwitch": false,
+        "allowDefaultCaseForExhaustiveSwitch": true,
         "considerDefaultExhaustiveForUnions": false,
         "requireDefaultForNonUnion": true
       }
@@ -144,6 +146,7 @@
     "unicorn/prefer-event-target": "off",
     "unicorn/prefer-includes": "off",
     "unicorn/prefer-number-coercion": "off",
+    "unicorn/prefer-string-starts-ends-with": "off",
     "unicorn/prefer-top-level-await": "off",
     "oxc/no-map-spread": "off",
     "unicorn/prefer-node-protocol": "error"

--- a/apps/api/.oxlintrc.json
+++ b/apps/api/.oxlintrc.json
@@ -1,18 +1,30 @@
 {
   "$schema": "../../node_modules/oxlint/configuration_schema.json",
   "extends": ["../../.oxlintrc.json"],
-  "plugins": [],
   "env": {
     "node": true
   },
   "categories": {
     "correctness": "error",
+    "perf": "error",
     "suspicious": "error"
   },
   "ignorePatterns": [".turbo/**", "coverage/**", "dist/**", "node_modules/**", "*.tsbuildinfo"],
   "rules": {
     "typescript/consistent-type-definitions": ["error", "interface"],
-    "typescript/strict-boolean-expressions": "error",
+    "typescript/strict-boolean-expressions": [
+      "error",
+      {
+        "allowAny": false,
+        "allowNullableBoolean": false,
+        "allowNullableEnum": false,
+        "allowNullableNumber": false,
+        "allowNullableObject": false,
+        "allowNullableString": false,
+        "allowNumber": false,
+        "allowString": false
+      }
+    ],
     "typescript/no-floating-promises": [
       "error",
       {
@@ -33,7 +45,7 @@
       {
         "allowDefaultCaseForExhaustiveSwitch": false,
         "considerDefaultExhaustiveForUnions": false,
-        "requireDefaultForNonUnion": false
+        "requireDefaultForNonUnion": true
       }
     ],
     "typescript/no-unsafe-argument": "error",
@@ -41,6 +53,9 @@
     "typescript/no-unsafe-call": "error",
     "typescript/no-unsafe-member-access": "error",
     "typescript/no-unsafe-return": "error",
+    "eslint/no-await-in-loop": "off",
+    "eslint/no-implied-eval": "off",
+    "oxc/no-map-spread": "off",
     "unicorn/prefer-node-protocol": "error"
   }
 }

--- a/apps/api/.oxlintrc.json
+++ b/apps/api/.oxlintrc.json
@@ -6,12 +6,69 @@
   },
   "categories": {
     "correctness": "error",
+    "pedantic": "error",
     "perf": "error",
+    "style": "error",
     "suspicious": "error"
   },
   "ignorePatterns": [".turbo/**", "coverage/**", "dist/**", "node_modules/**", "*.tsbuildinfo"],
   "rules": {
+    "eslint/max-lines-per-function": [
+      "error",
+      {
+        "IIFEs": true,
+        "max": 100,
+        "skipBlankLines": true,
+        "skipComments": true
+      }
+    ],
+    "eslint/max-statements": ["error", { "ignoreTopLevelFunctions": false, "max": 20 }],
+    "eslint/no-magic-numbers": [
+      "error",
+      {
+        "detectObjects": false,
+        "enforceConst": false,
+        "ignore": [-1, 0, 1],
+        "ignoreArrayIndexes": true,
+        "ignoreClassFieldInitialValues": false,
+        "ignoreDefaultValues": true,
+        "ignoreEnums": true,
+        "ignoreNumericLiteralTypes": true,
+        "ignoreReadonlyClassProperties": true,
+        "ignoreTypeIndexes": true
+      }
+    ],
+    "eslint/no-param-reassign": ["error", { "props": true }],
+    "eslint/sort-imports": ["error", { "ignoreDeclarationSort": true }],
+    "import/no-unassigned-import": [
+      "error",
+      { "allow": ["**/instrumentation.{js,ts}", "dotenv/config"] }
+    ],
+    "node/callback-return": ["error", ["callback", "cb"]],
     "typescript/consistent-type-definitions": ["error", "interface"],
+    "typescript/prefer-readonly-parameter-types": [
+      "error",
+      {
+        "allow": [
+          {
+            "from": "lib",
+            "name": ["AbortSignal", "Date", "Error", "Request", "Response"]
+          },
+          {
+            "from": "package",
+            "name": ["AddressInfo", "Buffer", "ErrnoException", "ProcessEnv"],
+            "package": "@types/node"
+          },
+          {
+            "from": "package",
+            "name": ["Context", "HTTPResponseError", "Next"],
+            "package": "hono"
+          }
+        ],
+        "ignoreInferredTypes": false,
+        "treatMethodsAsReadonly": true
+      }
+    ],
     "typescript/strict-boolean-expressions": [
       "error",
       {
@@ -33,7 +90,14 @@
         "ignoreVoid": false
       }
     ],
-    "typescript/no-misused-promises": "error",
+    "typescript/no-misused-promises": [
+      "error",
+      {
+        "checksConditionals": true,
+        "checksSpreads": true,
+        "checksVoidReturn": false
+      }
+    ],
     "typescript/no-unnecessary-condition": [
       "error",
       {
@@ -53,8 +117,34 @@
     "typescript/no-unsafe-call": "error",
     "typescript/no-unsafe-member-access": "error",
     "typescript/no-unsafe-return": "error",
+
+    "eslint/init-declarations": "off",
     "eslint/no-await-in-loop": "off",
+    "eslint/no-duplicate-imports": "off",
     "eslint/no-implied-eval": "off",
+    "eslint/no-new-wrappers": "off",
+    "eslint/no-ternary": "off",
+    "eslint/no-throw-literal": "off",
+    "eslint/prefer-promise-reject-errors": "off",
+    "eslint/require-await": "off",
+    "import/exports-last": "off",
+    "import/group-exports": "off",
+    "import/no-named-export": "off",
+    "import/no-nodejs-modules": "off",
+    "import/prefer-default-export": "off",
+    "promise/avoid-new": "off",
+    "promise/prefer-await-to-callbacks": "off",
+    "promise/prefer-await-to-then": "off",
+    "typescript/no-empty-interface": "off",
+    "typescript/prefer-find": "off",
+    "unicorn/explicit-length-check": "off",
+    "unicorn/no-negated-condition": "off",
+    "unicorn/no-nested-ternary": "off",
+    "unicorn/no-null": "off",
+    "unicorn/prefer-event-target": "off",
+    "unicorn/prefer-includes": "off",
+    "unicorn/prefer-number-coercion": "off",
+    "unicorn/prefer-top-level-await": "off",
     "oxc/no-map-spread": "off",
     "unicorn/prefer-node-protocol": "error"
   }

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -3,9 +3,7 @@ import { Hono } from 'hono';
 
 const app = new Hono();
 
-app.get('/', (c) => {
-  return c.text('Hello Hono!');
-});
+app.get('/', (context) => context.text('Hello Hono!'));
 
 serve(
   {

--- a/apps/web/.oxlintrc.json
+++ b/apps/web/.oxlintrc.json
@@ -1,7 +1,7 @@
 {
   "$schema": "../../node_modules/oxlint/configuration_schema.json",
   "extends": ["../../.oxlintrc.json"],
-  "plugins": ["jsdoc", "jsx-a11y", "nextjs", "react", "react-perf", "vitest"],
+  "plugins": ["jsdoc", "jsx-a11y", "nextjs", "react"],
   "env": {
     "browser": true,
     "node": true
@@ -14,6 +14,7 @@
   "categories": {
     "correctness": "error",
     "pedantic": "error",
+    "perf": "error",
     "suspicious": "error",
     "style": "error"
   },
@@ -28,10 +29,20 @@
   ],
   "overrides": [
     {
-      "files": ["e2e/**/*.spec.{ts,tsx}"],
+      "files": ["**/*.{jsx,tsx}"],
       "rules": {
-        "vitest/consistent-test-filename": "off",
-        "vitest/prefer-importing-vitest-globals": "off"
+        "eslint/func-style": "off"
+      }
+    },
+    {
+      "files": ["src/**/*.test.{ts,tsx}", "tests/integration/**/*.integration.test.{ts,tsx}"],
+      "plugins": ["vitest"],
+      "rules": {
+        "vitest/consistent-test-it": ["error", { "fn": "test" }],
+        "vitest/no-importing-vitest-globals": "off",
+        "vitest/prefer-expect-assertions": "off",
+        "vitest/prefer-to-be-falsy": "off",
+        "vitest/prefer-to-be-truthy": "off"
       }
     }
   ],
@@ -43,9 +54,21 @@
       { "allow": ["**/*.css", "server-only", "client-only"] }
     ],
     "react/jsx-no-constructed-context-values": "error",
-    "react/no-object-type-as-default-prop": "error",
-    "react/react-compiler": "error",
-    "vitest/consistent-test-it": ["error", { "fn": "test" }],
+    "react/no-object-type-as-default-prop": "off",
+    "react/react-compiler": ["error", { "reportAllBailouts": false }],
+    "typescript/strict-boolean-expressions": [
+      "error",
+      {
+        "allowAny": false,
+        "allowNullableBoolean": false,
+        "allowNullableEnum": false,
+        "allowNullableNumber": false,
+        "allowNullableObject": false,
+        "allowNullableString": false,
+        "allowNumber": false,
+        "allowString": false
+      }
+    ],
 
     "eslint/id-length": "off",
     "eslint/max-classes-per-file": "off",
@@ -56,6 +79,8 @@
     "eslint/max-params": "off",
     "eslint/max-statements": "off",
     "eslint/new-cap": "off",
+    "eslint/no-await-in-loop": "off",
+    "eslint/no-duplicate-imports": "off",
     "eslint/no-inline-comments": "off",
     "eslint/no-magic-numbers": "off",
     "eslint/no-warning-comments": "off",
@@ -77,6 +102,7 @@
     "jsdoc/require-yields-description": "off",
     "jsdoc/require-yields-type": "off",
     "node/no-sync": "off",
+    "oxc/no-map-spread": "off",
     "promise/avoid-new": "off",
     "promise/prefer-await-to-callbacks": "off",
     "promise/prefer-await-to-then": "off",
@@ -84,14 +110,13 @@
     "react/react-in-jsx-scope": "off",
     "react/jsx-max-depth": "off",
     "react/jsx-props-no-spreading": "off",
-    "vitest/no-importing-vitest-globals": "off",
-    "vitest/prefer-expect-assertions": "off",
-    "vitest/prefer-to-be-falsy": "off",
-    "vitest/prefer-to-be-truthy": "off",
     "import/no-named-export": "off",
     "import/prefer-default-export": "off",
     "import/no-nodejs-modules": "off",
     "unicorn/no-null": "off",
+    "unicorn/no-negated-condition": "off",
+    "unicorn/no-nested-ternary": "off",
+    "unicorn/prefer-includes": "off",
     "eslint/no-ternary": "off",
     "eslint/no-underscore-dangle": "off",
     "eslint/no-implied-eval": "off",
@@ -99,6 +124,7 @@
     "eslint/prefer-promise-reject-errors": "off",
     "eslint/require-await": "off",
     "react/no-array-index-key": "error",
+    "typescript/prefer-find": "off",
     "typescript/prefer-readonly-parameter-types": "off",
     "eslint/no-proto": "error",
     "react/button-has-type": "error",

--- a/apps/web/.oxlintrc.json
+++ b/apps/web/.oxlintrc.json
@@ -35,11 +35,29 @@
       }
     },
     {
+      "files": ["**/*.{js,mjs,mts,ts,tsx}"],
+      "rules": {
+        "eslint/no-restricted-imports": [
+          "error",
+          {
+            "paths": [
+              {
+                "name": "vitest",
+                "message": "Vitest files must use a configured .test.ts or .test.tsx filename."
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
       "files": ["src/**/*.test.{ts,tsx}", "tests/integration/**/*.integration.test.{ts,tsx}"],
       "plugins": ["vitest"],
       "rules": {
+        "eslint/no-restricted-imports": "off",
         "vitest/consistent-test-it": ["error", { "fn": "test" }],
         "vitest/no-importing-vitest-globals": "off",
+        "vitest/no-hooks": "off",
         "vitest/prefer-expect-assertions": "off",
         "vitest/prefer-to-be-falsy": "off",
         "vitest/prefer-to-be-truthy": "off"
@@ -49,9 +67,27 @@
   "rules": {
     "eslint/no-param-reassign": ["error", { "props": true }],
     "eslint/sort-imports": ["error", { "ignoreDeclarationSort": true }],
+    "import/no-namespace": ["error", { "ignore": ["@stylexjs/stylex"] }],
+    "unicorn/import-style": [
+      "error",
+      {
+        "checkDynamicImport": true,
+        "checkExportFrom": true,
+        "checkImport": true,
+        "checkRequire": true,
+        "extendDefaultStyles": true,
+        "styles": {
+          "@stylexjs/stylex": { "namespace": true }
+        }
+      }
+    ],
     "import/no-unassigned-import": [
       "error",
       { "allow": ["**/*.css", "server-only", "client-only"] }
+    ],
+    "react/jsx-filename-extension": [
+      "error",
+      { "allow": "as-needed", "extensions": [".tsx"], "ignoreFilesWithoutCode": false }
     ],
     "react/jsx-no-constructed-context-values": "error",
     "react/no-object-type-as-default-prop": "off",
@@ -69,6 +105,23 @@
         "allowString": false
       }
     ],
+    "typescript/no-floating-promises": [
+      "error",
+      {
+        "checkThenables": true,
+        "ignoreIIFE": false,
+        "ignoreVoid": false
+      }
+    ],
+    "typescript/no-misused-promises": [
+      "error",
+      {
+        "checksConditionals": true,
+        "checksSpreads": false,
+        "checksVoidReturn": false
+      }
+    ],
+    "typescript/strict-void-return": ["error", { "allowReturnAny": false }],
 
     "eslint/id-length": "off",
     "eslint/max-classes-per-file": "off",
@@ -117,6 +170,7 @@
     "unicorn/no-negated-condition": "off",
     "unicorn/no-nested-ternary": "off",
     "unicorn/prefer-includes": "off",
+    "unicorn/prefer-string-starts-ends-with": "off",
     "eslint/no-ternary": "off",
     "eslint/no-underscore-dangle": "off",
     "eslint/no-implied-eval": "off",

--- a/apps/web/.oxlintrc.json
+++ b/apps/web/.oxlintrc.json
@@ -29,7 +29,7 @@
   ],
   "overrides": [
     {
-      "files": ["**/*.{jsx,tsx}"],
+      "files": ["**/*.tsx"],
       "rules": {
         "eslint/func-style": "off"
       }

--- a/apps/web/postcss.config.mjs
+++ b/apps/web/postcss.config.mjs
@@ -10,7 +10,7 @@ const config = {
         },
         plugins: babelConfig.plugins,
       },
-      include: ['src/**/*.{js,jsx,ts,tsx}'],
+      include: ['src/**/*.{js,ts,tsx}'],
       useCSSLayers: true,
     },
     autoprefixer: {},

--- a/apps/web/src/app/page.tsx
+++ b/apps/web/src/app/page.tsx
@@ -1,7 +1,7 @@
-import { create, props } from '@stylexjs/stylex';
+import * as stylex from '@stylexjs/stylex';
 import Image from 'next/image';
 
-const styles = create({
+const styles = stylex.create({
   page: {
     alignItems: 'center',
     backgroundColor: {
@@ -146,22 +146,22 @@ const styles = create({
 
 export default function Home() {
   return (
-    <div {...props(styles.page)}>
-      <main {...props(styles.main)}>
+    <div {...stylex.props(styles.page)}>
+      <main {...stylex.props(styles.main)}>
         <Image
-          {...props(styles.logo)}
+          {...stylex.props(styles.logo)}
           src="/next.svg"
           alt="Next.js logo"
           width={100}
           height={20}
           priority
         />
-        <div {...props(styles.intro)}>
-          <h1 {...props(styles.introTitle)}>To get started, edit the page.tsx file.</h1>
-          <p {...props(styles.introText)}>
+        <div {...stylex.props(styles.intro)}>
+          <h1 {...stylex.props(styles.introTitle)}>To get started, edit the page.tsx file.</h1>
+          <p {...stylex.props(styles.introText)}>
             Looking for a starting point or more instructions? Head over to{' '}
             <a
-              {...props(styles.introLink)}
+              {...stylex.props(styles.introLink)}
               href="https://vercel.com/templates?framework=next.js&utm_source=create-next-app&utm_medium=appdir-template-tw&utm_campaign=create-next-app"
               target="_blank"
               rel="noopener noreferrer"
@@ -170,7 +170,7 @@ export default function Home() {
             </a>{' '}
             or the{' '}
             <a
-              {...props(styles.introLink)}
+              {...stylex.props(styles.introLink)}
               href="https://nextjs.org/learn?utm_source=create-next-app&utm_medium=appdir-template-tw&utm_campaign=create-next-app"
               target="_blank"
               rel="noopener noreferrer"
@@ -180,15 +180,15 @@ export default function Home() {
             center.
           </p>
         </div>
-        <div {...props(styles.ctas)}>
+        <div {...stylex.props(styles.ctas)}>
           <a
-            {...props(styles.cta, styles.primary)}
+            {...stylex.props(styles.cta, styles.primary)}
             href="https://vercel.com/new?utm_source=create-next-app&utm_medium=appdir-template&utm_campaign=create-next-app"
             target="_blank"
             rel="noopener noreferrer"
           >
             <Image
-              {...props(styles.logo)}
+              {...stylex.props(styles.logo)}
               src="/vercel.svg"
               alt="Vercel logomark"
               width={16}
@@ -197,7 +197,7 @@ export default function Home() {
             Deploy Now
           </a>
           <a
-            {...props(styles.cta, styles.secondary)}
+            {...stylex.props(styles.cta, styles.secondary)}
             href="https://nextjs.org/docs?utm_source=create-next-app&utm_medium=appdir-template&utm_campaign=create-next-app"
             target="_blank"
             rel="noopener noreferrer"

--- a/apps/web/src/app/providers.tsx
+++ b/apps/web/src/app/providers.tsx
@@ -5,7 +5,6 @@ import type { ReactNode } from 'react';
 
 import { getQueryClient } from '@/lib/query/query-client';
 
-// oxlint-disable-next-line eslint/func-style -- React components are function declarations.
 export function Providers({ children }: Readonly<{ children: ReactNode }>) {
   const queryClient = getQueryClient();
 

--- a/turbo.json
+++ b/turbo.json
@@ -14,7 +14,8 @@
     },
     "format:check": {},
     "lint": {
-      "dependsOn": ["^lint"]
+      "dependsOn": ["^lint"],
+      "inputs": ["$TURBO_DEFAULT$", "$TURBO_ROOT$/.oxlintrc.json"]
     },
     "lint:fix": {
       "cache": false


### PR DESCRIPTION
## Summary

- strengthen shared, Web, and API Oxlint policies with explicit strict options
- remove duplicate diagnostic owners for ternaries, imports, non-null assertions, promises, implied eval, and string prefix/suffix checks
- scope Vitest rules to configured tests and reject skipped Vitest filenames
- enforce TSX-only JSX and the repository's StyleX namespace import convention
- calibrate API style, pedantic, performance, runtime validation, and exhaustive-switch rules against Hono and Node.js patterns

## Validation

- real React/Next, Vitest, StyleX, Promise, Hono, runtime type-predicate, async external-state, and switch fixtures
- forced format, lint, type-check, unit-test, production-build, and Playwright gates

Middle layer of stack #9; depends on #7.