### PR TITLE
build: make quality checks cache-safe

### DIFF
--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -53,7 +53,7 @@ jobs:
         run: pnpm install --frozen-lockfile
 
       - name: Generate Next.js types
-        run: pnpm --filter @repo/web exec next typegen
+        run: pnpm --filter @repo/web typegen
 
       - name: Check formatting
         run: pnpm exec turbo run format:check --force

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -15,6 +15,7 @@
     "test:e2e": "playwright test",
     "test:e2e:ui": "playwright test --ui",
     "test:watch": "vitest",
+    "typegen": "next typegen",
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {

--- a/turbo.json
+++ b/turbo.json
@@ -14,8 +14,13 @@
     },
     "format:check": {},
     "lint": {
+      "cache": false,
       "dependsOn": ["^lint"],
-      "inputs": ["$TURBO_DEFAULT$", "$TURBO_ROOT$/.oxlintrc.json"]
+      "inputs": [
+        "$TURBO_DEFAULT$",
+        "$TURBO_ROOT$/.gitignore",
+        "$TURBO_ROOT$/.oxlintrc.json"
+      ]
     },
     "lint:fix": {
       "cache": false
@@ -47,6 +52,7 @@
       "persistent": true
     },
     "typecheck": {
+      "cache": false,
       "dependsOn": ["^typecheck"]
     }
   }


### PR DESCRIPTION
## Summary

- disable Turbo caching for lint and type-check tasks whose effective inputs include Git ignore state or ignored Next.js generated types
- include the shared ignore and Oxlint policy files in lint task inputs
- add an explicit Web typegen script and invoke it in clean-checkout CI

## Validation

- repeated lint/type-check runs confirmed zero cache hits
- stale ignored Next.js generated type was detected instead of replaying a successful type-check
- formatting, linting, type checking, unit tests, production builds, and Playwright E2E passed

Top layer of stack #9; depends on #6.