### PR TITLE
chore: align Node and pnpm toolchain

### DIFF
--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -29,16 +29,14 @@ jobs:
         with:
           persist-credentials: false
 
+      - name: Set up pnpm
+        uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
+
       - name: Set up Node.js
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version-file: .node-version
           package-manager-cache: false
-
-      - name: Activate project pnpm
-        run: |
-          corepack enable
-          corepack install
 
       - name: Verify runtime versions
         run: |
@@ -82,16 +80,14 @@ jobs:
         with:
           persist-credentials: false
 
+      - name: Set up pnpm
+        uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
+
       - name: Set up Node.js
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version-file: .node-version
           package-manager-cache: false
-
-      - name: Activate project pnpm
-        run: |
-          corepack enable
-          corepack install
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -16,7 +16,7 @@
     "hono": "^4.12.32"
   },
   "devDependencies": {
-    "@types/node": "^26.1.1",
+    "@types/node": "^24.13.3",
     "oxfmt": "0.60.0",
     "tsx": "^4.23.0",
     "typescript": "^7.0.2"

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "monorepo-template",
   "version": "0.1.0",
   "private": true,
-  "packageManager": "pnpm@11.18.0+sha512.33d83c77da82f49fba836925c6f1b841181ec3132b670639bd012f7075f5c7cf634c5f870147c19aae7478fac01df09d8892e880454896edd23ee9b33757563c",
+  "packageManager": "pnpm@11.18.0",
   "engines": {
     "node": "^24.18.1"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -28,8 +28,8 @@ importers:
         version: 4.12.32
     devDependencies:
       '@types/node':
-        specifier: ^26.1.1
-        version: 26.1.1
+        specifier: ^24.13.3
+        version: 24.13.3
       oxfmt:
         specifier: 0.60.0
         version: 0.60.0
@@ -1053,9 +1053,6 @@ packages:
   '@types/node@24.13.3':
     resolution: {integrity: sha512-Dh8vAsV36ig5wa9OX4pXvMc9D3Veibfw2wix0CUwYODLD8nkj9UsLjASr49nPg+2eKzxhBV+v7L8pXvT4e639Q==}
 
-  '@types/node@26.1.1':
-    resolution: {integrity: sha512-nxAkRSVkN1Y0JC1W8ky/fTfkGsMmcrRsbx+3XoZE+rMOX71kLYTV7fLXpqud1GpbpP5TuffXFqfX7fH2GgZREw==}
-
   '@types/react-dom@19.2.3':
     resolution: {integrity: sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==}
     peerDependencies:
@@ -1736,9 +1733,6 @@ packages:
 
   undici-types@7.18.2:
     resolution: {integrity: sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==}
-
-  undici-types@8.3.0:
-    resolution: {integrity: sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ==}
 
   update-browserslist-db@1.2.3:
     resolution: {integrity: sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==}
@@ -2505,10 +2499,6 @@ snapshots:
     dependencies:
       undici-types: 7.18.2
 
-  '@types/node@26.1.1':
-    dependencies:
-      undici-types: 8.3.0
-
   '@types/react-dom@19.2.3(@types/react@19.2.17)':
     dependencies:
       '@types/react': 19.2.17
@@ -3169,8 +3159,6 @@ snapshots:
       '@typescript/typescript-win32-x64': 7.0.2
 
   undici-types@7.18.2: {}
-
-  undici-types@8.3.0: {}
 
   update-browserslist-db@1.2.3(browserslist@4.28.7):
     dependencies:


### PR DESCRIPTION
## Summary

- replace bundled Corepack bootstrap steps with the official `pnpm/action-setup`, pinned to the `v6.0.9` commit
- keep the root package-manager declaration as the exact `pnpm@11.18.0` version without Corepack-only integrity metadata
- align the API workspace's Node types with the repository's Node 24 LTS runtime and update the lockfile

## Why

Node no longer distributes Corepack starting with Node 25, so the current CI bootstrap would block a future LTS transition. The API workspace also declared Node 26 types while the runtime contract remains Node 24.

## Impact

CI continues to install the exact pnpm version declared in the root package manifest. Runtime declarations and Node type packages now share the Node 24 baseline. README updates are intentionally out of scope.

## Validation

- `pnpm install --frozen-lockfile`
- `pnpm --filter @repo/web typegen`
- `pnpm exec turbo run format:check --force`
- `pnpm exec turbo run lint --force`
- `pnpm exec turbo run typecheck --force`
- `pnpm exec turbo run test --force`
- `pnpm exec turbo run build --force`
- workflow YAML parse and `git diff --check`
- verified the pinned action SHA against the official `v6.0.9` tag

Local checks ran with Node 24.17.0 and pnpm 11.18.0; CI installs the repository-pinned Node 24.18.1.