### PR TITLE
chore: configure Renovate dependency updates

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -7,15 +7,5 @@ allowBuilds:
   sharp: false
   unrs-resolver: false
 
-minimumReleaseAgeExclude:
-  - "@next/*"
-  - "@oxfmt/*"
-  - "@oxlint/*"
-  - "@oxlint-tsgolint/*"
-  - next
-  - oxfmt
-  - oxlint
-  - oxlint-tsgolint
-  - react@19.2.8
-  - react-dom@19.2.8
-  - '@hono/node-server@2.0.12'
+minimumReleaseAge: 4320
+minimumReleaseAgeStrict: true

--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,37 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": [
+    "config:best-practices",
+    "customManagers:dockerfileVersions",
+    ":semanticCommits",
+    ":timezone(Asia/Tokyo)"
+  ],
+  "packageRules": [
+    {
+      "description": "Keep Node.js runtime declarations synchronized",
+      "matchDatasources": ["node-version"],
+      "matchPackageNames": ["node"],
+      "groupName": "Node.js LTS",
+      "rangeStrategy": "bump"
+    },
+    {
+      "description": "Move Node.js types with the LTS line",
+      "matchManagers": ["npm"],
+      "matchPackageNames": ["@types/node"],
+      "groupName": "Node.js LTS"
+    },
+    {
+      "description": "Track Next.js canary releases after the cooldown",
+      "matchManagers": ["npm"],
+      "matchPackageNames": ["next"],
+      "ignoreUnstable": false,
+      "respectLatest": false
+    },
+    {
+      "description": "Group StyleX packages",
+      "matchManagers": ["npm"],
+      "matchPackageNames": ["@stylexjs/**"],
+      "groupName": "StyleX"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

- add a Renovate configuration based on `config:best-practices`
- enable Dockerfile version annotations, semantic commits, and the Asia/Tokyo timezone preset
- keep Node runtime declarations and `@types/node` on the same LTS update line
- keep tracking mature Next.js canary releases and group StyleX package updates
- replace broad pnpm release-age exclusions with a strict 3-day minimum release age

## Why

The repository has dependency surfaces across pnpm workspaces, GitHub Actions, Node runtime declarations, and Docker Compose. A preset-first Renovate configuration covers those surfaces while retaining only the repository-specific rules that are needed.

Renovate's 3-day npm cooldown protects direct update proposals. pnpm's `minimumReleaseAge: 4320` with strict mode applies the same acceptance policy during lockfile resolution, including transitive dependencies.

## Impact

- npm, GitHub Actions, Node, and Docker Compose dependencies become Renovate-managed
- Docker image digests and GitHub Action SHAs remain pinned through the best-practices preset
- standard Dockerfile `FROM` references will be detected natively; annotated `ARG`/`ENV` versions are ready for future Dockerfiles
- no automerge is enabled
- existing broad release-age bypasses are removed
- README changes remain out of scope

Recommended merge order: merge #11 first, then this PR. The branches are independent and merge without conflicts.

## Validation

- `npx --yes --package renovate@44.7.1 renovate-config-validator renovate.json`
- `LOG_LEVEL=info npx --yes renovate@44.7.1 --platform=local --dry-run=extract`
  - current `main`: 7 package files / 38 references
  - after #11: 7 package files / 40 references, including both `pnpm/action-setup` uses
- `pnpm install --frozen-lockfile` with the strict 3-day policy
- `git diff --check`
- conflict-free merge-tree check against #11

The local Renovate extraction warning about a missing GitHub token is expected for local platform mode; the repository configuration validated successfully.