### PR TITLE
chore: ignore IntelliJ IDEA files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,6 +27,7 @@ build/
 
 # misc
 .DS_Store
+.idea/
 *.pem
 
 # debug


### PR DESCRIPTION
## Summary

- Add `.idea/` to the repository-level `.gitignore`.

## Why

IntelliJ IDEA project metadata is local editor state and should not be considered for version control. The root cause was that the repository ignore rules did not include the IDE metadata directory.

## Impact

Developers using IntelliJ-based IDEs will no longer see `.idea` files as untracked changes.

## Validation

- `git diff --check`
- `git check-ignore -v --no-index .idea/workspace.xml`