### PR TITLE
build(api): refine Oxlint harness policy

### DIFF
--- a/apps/api/.oxlintrc.json
+++ b/apps/api/.oxlintrc.json
@@ -18,61 +18,34 @@
     "suspicious": "error"
   },
   "ignorePatterns": [".turbo/**", "coverage/**", "dist/**", "node_modules/**", "*.tsbuildinfo"],
+  "overrides": [
+    {
+      "files": ["**/*.{js,mjs,cjs}"],
+      "rules": {
+        "eslint/no-undef": "error"
+      }
+    }
+  ],
   "rules": {
-    "typescript/no-confusing-non-null-assertion": "off",
-    "typescript/no-empty-object-type": "error",
-    "typescript/no-explicit-any": "error",
-    "typescript/no-extra-non-null-assertion": "off",
-    "typescript/no-import-type-side-effects": "error",
-    "typescript/no-invalid-void-type": "error",
-    "typescript/no-non-null-asserted-nullish-coalescing": "off",
-    "typescript/no-non-null-asserted-optional-chain": "off",
-    "typescript/no-non-null-assertion": "error",
-    "typescript/no-require-imports": "error",
-    "typescript/use-unknown-in-catch-callback-variable": "error",
-    "import/no-cycle": "error",
-    "node/no-path-concat": "error",
-    "oxc/no-accumulating-spread": "error",
-    "unicorn/no-abusive-eslint-disable": "error",
-    "unicorn/no-useless-error-capture-stack-trace": "error",
-    "unicorn/no-array-sort": [
-      "error",
-      { "allowAfterSpread": true, "allowExpressionStatement": false }
-    ],
-    "eslint/complexity": ["error", { "max": 20, "variant": "classic" }],
-    "eslint/max-lines-per-function": [
-      "error",
-      {
-        "IIFEs": true,
-        "max": 100,
-        "skipBlankLines": true,
-        "skipComments": true
-      }
-    ],
-    "eslint/max-statements": ["error", { "ignoreTopLevelFunctions": false, "max": 20 }],
-    "eslint/no-magic-numbers": [
-      "error",
-      {
-        "detectObjects": false,
-        "enforceConst": false,
-        "ignore": [-1, 0, 1],
-        "ignoreArrayIndexes": true,
-        "ignoreClassFieldInitialValues": false,
-        "ignoreDefaultValues": true,
-        "ignoreEnums": true,
-        "ignoreNumericLiteralTypes": true,
-        "ignoreReadonlyClassProperties": true,
-        "ignoreTypeIndexes": true
-      }
-    ],
     "eslint/no-param-reassign": ["error", { "props": true }],
-    "eslint/sort-imports": ["error", { "ignoreDeclarationSort": true }],
+    "eslint/no-proto": "error",
+    "import/no-cycle": "error",
     "import/no-unassigned-import": [
       "error",
       { "allow": ["**/instrumentation.{js,ts}", "dotenv/config"] }
     ],
     "node/callback-return": ["error", ["callback", "cb"]],
-    "typescript/consistent-type-definitions": ["error", "interface"],
+    "node/no-path-concat": "error",
+    "typescript/no-confusing-non-null-assertion": "off",
+    "typescript/no-empty-object-type": "error",
+    "typescript/no-explicit-any": "error",
+    "typescript/no-extra-non-null-assertion": "off",
+    "typescript/no-floating-promises": ["error", { "checkThenables": true, "ignoreVoid": false }],
+    "typescript/no-import-type-side-effects": "error",
+    "typescript/no-invalid-void-type": "error",
+    "typescript/no-non-null-asserted-optional-chain": "off",
+    "typescript/no-non-null-assertion": "error",
+    "typescript/no-require-imports": "error",
     "typescript/prefer-readonly-parameter-types": [
       "error",
       {
@@ -92,80 +65,64 @@
             "package": "hono"
           }
         ],
-        "ignoreInferredTypes": false,
         "treatMethodsAsReadonly": true
       }
     ],
     "typescript/strict-boolean-expressions": [
       "error",
       {
-        "allowAny": false,
-        "allowNullableBoolean": false,
-        "allowNullableEnum": false,
-        "allowNullableNumber": false,
         "allowNullableObject": false,
-        "allowNullableString": false,
         "allowNumber": false,
         "allowString": false
       }
     ],
-    "typescript/no-floating-promises": [
+    "typescript/switch-exhaustiveness-check": ["error", { "requireDefaultForNonUnion": true }],
+    "typescript/use-unknown-in-catch-callback-variable": "error",
+    "unicorn/no-abusive-eslint-disable": "error",
+    "unicorn/no-array-sort": [
       "error",
-      {
-        "checkThenables": true,
-        "ignoreIIFE": false,
-        "ignoreVoid": false
-      }
+      { "allowAfterSpread": true, "allowExpressionStatement": false }
     ],
-    "typescript/no-misused-promises": [
-      "error",
-      {
-        "checksConditionals": true,
-        "checksSpreads": false,
-        "checksVoidReturn": false
-      }
-    ],
-    "typescript/strict-void-return": ["error", { "allowReturnAny": false }],
-    "typescript/no-unnecessary-condition": [
-      "error",
-      {
-        "checkTypePredicates": false
-      }
-    ],
-    "typescript/switch-exhaustiveness-check": [
-      "error",
-      {
-        "allowDefaultCaseForExhaustiveSwitch": true,
-        "considerDefaultExhaustiveForUnions": false,
-        "requireDefaultForNonUnion": true
-      }
-    ],
-    "typescript/no-unsafe-argument": "error",
-    "typescript/no-unsafe-assignment": "error",
-    "typescript/no-unsafe-call": "error",
-    "typescript/no-unsafe-member-access": "error",
-    "typescript/no-unsafe-return": "error",
+    "unicorn/no-useless-error-capture-stack-trace": "error",
+    "unicorn/prefer-node-protocol": "error",
 
+    "eslint/id-length": "off",
     "eslint/init-declarations": "off",
+    "eslint/max-classes-per-file": "off",
+    "eslint/max-depth": "off",
+    "eslint/max-lines": "off",
+    "eslint/max-lines-per-function": "off",
+    "eslint/max-nested-callbacks": "off",
+    "eslint/max-params": "off",
+    "eslint/max-statements": "off",
+    "eslint/new-cap": "off",
     "eslint/no-await-in-loop": "off",
     "eslint/no-duplicate-imports": "off",
     "eslint/no-implied-eval": "off",
+    "eslint/no-magic-numbers": "off",
     "eslint/no-new-wrappers": "off",
     "eslint/no-ternary": "off",
     "eslint/no-throw-literal": "off",
+    "eslint/no-underscore-dangle": "off",
     "eslint/prefer-promise-reject-errors": "off",
     "eslint/require-await": "off",
+    "eslint/sort-imports": "off",
+    "eslint/sort-keys": "off",
+    "eslint/sort-vars": "off",
     "import/exports-last": "off",
     "import/group-exports": "off",
+    "import/max-dependencies": "off",
     "import/no-named-export": "off",
     "import/no-nodejs-modules": "off",
     "import/prefer-default-export": "off",
+    "oxc/no-map-spread": "off",
     "promise/avoid-new": "off",
     "promise/prefer-await-to-callbacks": "off",
     "promise/prefer-await-to-then": "off",
     "typescript/no-empty-interface": "off",
     "typescript/prefer-find": "off",
     "unicorn/explicit-length-check": "off",
+    "unicorn/max-nested-calls": "off",
     "unicorn/no-negated-condition": "off",
     "unicorn/no-nested-ternary": "off",
     "unicorn/no-null": "off",
@@ -173,8 +130,6 @@
     "unicorn/prefer-includes": "off",
     "unicorn/prefer-number-coercion": "off",
     "unicorn/prefer-string-starts-ends-with": "off",
-    "unicorn/prefer-top-level-await": "off",
-    "oxc/no-map-spread": "off",
-    "unicorn/prefer-node-protocol": "error"
+    "unicorn/prefer-top-level-await": "off"
   }
 }

--- a/apps/api/.oxlintrc.json
+++ b/apps/api/.oxlintrc.json
@@ -12,80 +12,12 @@
   },
   "categories": {
     "correctness": "error",
+    "suspicious": "error",
     "pedantic": "error",
     "perf": "error",
-    "style": "error",
-    "suspicious": "error"
+    "style": "error"
   },
-  "ignorePatterns": [".turbo/**", "coverage/**", "dist/**", "node_modules/**", "*.tsbuildinfo"],
-  "overrides": [
-    {
-      "files": ["**/*.{js,mjs,cjs}"],
-      "rules": {
-        "eslint/no-undef": "error"
-      }
-    }
-  ],
   "rules": {
-    "eslint/no-param-reassign": ["error", { "props": true }],
-    "eslint/no-proto": "error",
-    "import/no-cycle": "error",
-    "import/no-unassigned-import": [
-      "error",
-      { "allow": ["**/instrumentation.{js,ts}", "dotenv/config"] }
-    ],
-    "node/callback-return": ["error", ["callback", "cb"]],
-    "node/no-path-concat": "error",
-    "typescript/no-confusing-non-null-assertion": "off",
-    "typescript/no-empty-object-type": "error",
-    "typescript/no-explicit-any": "error",
-    "typescript/no-extra-non-null-assertion": "off",
-    "typescript/no-floating-promises": ["error", { "checkThenables": true, "ignoreVoid": false }],
-    "typescript/no-import-type-side-effects": "error",
-    "typescript/no-invalid-void-type": "error",
-    "typescript/no-non-null-asserted-optional-chain": "off",
-    "typescript/no-non-null-assertion": "error",
-    "typescript/no-require-imports": "error",
-    "typescript/prefer-readonly-parameter-types": [
-      "error",
-      {
-        "allow": [
-          {
-            "from": "lib",
-            "name": ["AbortSignal", "Date", "Error", "Request", "Response"]
-          },
-          {
-            "from": "package",
-            "name": ["AddressInfo", "Buffer", "ErrnoException", "ProcessEnv"],
-            "package": "@types/node"
-          },
-          {
-            "from": "package",
-            "name": ["Context", "HTTPResponseError", "Next"],
-            "package": "hono"
-          }
-        ],
-        "treatMethodsAsReadonly": true
-      }
-    ],
-    "typescript/strict-boolean-expressions": [
-      "error",
-      {
-        "allowNullableObject": false,
-        "allowNumber": false,
-        "allowString": false
-      }
-    ],
-    "typescript/switch-exhaustiveness-check": ["error", { "requireDefaultForNonUnion": true }],
-    "typescript/use-unknown-in-catch-callback-variable": "error",
-    "unicorn/no-abusive-eslint-disable": "error",
-    "unicorn/no-array-sort": [
-      "error",
-      { "allowAfterSpread": true, "allowExpressionStatement": false }
-    ],
-    "unicorn/no-useless-error-capture-stack-trace": "error",
-    "unicorn/prefer-node-protocol": "error",
-
     "eslint/id-length": "off",
     "eslint/init-declarations": "off",
     "eslint/max-classes-per-file": "off",
@@ -119,7 +51,10 @@
     "promise/avoid-new": "off",
     "promise/prefer-await-to-callbacks": "off",
     "promise/prefer-await-to-then": "off",
+    "typescript/no-confusing-non-null-assertion": "off",
     "typescript/no-empty-interface": "off",
+    "typescript/no-extra-non-null-assertion": "off",
+    "typescript/no-non-null-asserted-optional-chain": "off",
     "typescript/prefer-find": "off",
     "unicorn/explicit-length-check": "off",
     "unicorn/max-nested-calls": "off",
@@ -130,6 +65,53 @@
     "unicorn/prefer-includes": "off",
     "unicorn/prefer-number-coercion": "off",
     "unicorn/prefer-string-starts-ends-with": "off",
-    "unicorn/prefer-top-level-await": "off"
-  }
+    "unicorn/prefer-top-level-await": "off",
+
+    "eslint/no-param-reassign": ["error", { "props": true }],
+    "eslint/no-proto": "error",
+    "import/no-cycle": "error",
+    "import/no-unassigned-import": [
+      "error",
+      { "allow": ["**/instrumentation.{js,ts}", "dotenv/config"] }
+    ],
+    "node/callback-return": ["error", ["callback", "cb"]],
+    "node/no-path-concat": "error",
+    "typescript/no-empty-object-type": "error",
+    "typescript/no-explicit-any": "error",
+    "typescript/no-floating-promises": ["error", { "checkThenables": true, "ignoreVoid": false }],
+    "typescript/no-import-type-side-effects": "error",
+    "typescript/no-invalid-void-type": "error",
+    "typescript/no-non-null-assertion": "error",
+    "typescript/no-require-imports": "error",
+    "typescript/prefer-readonly-parameter-types": [
+      "error",
+      {
+        "allow": [
+          { "from": "lib", "name": ["AbortSignal", "Date", "Error", "Request", "Response"] },
+          {
+            "from": "package",
+            "name": ["AddressInfo", "Buffer", "ErrnoException", "ProcessEnv"],
+            "package": "@types/node"
+          },
+          { "from": "package", "name": ["Context", "HTTPResponseError", "Next"], "package": "hono" }
+        ],
+        "treatMethodsAsReadonly": true
+      }
+    ],
+    "typescript/strict-boolean-expressions": [
+      "error",
+      { "allowNullableObject": false, "allowNumber": false, "allowString": false }
+    ],
+    "typescript/switch-exhaustiveness-check": ["error", { "requireDefaultForNonUnion": true }],
+    "typescript/use-unknown-in-catch-callback-variable": "error",
+    "unicorn/no-abusive-eslint-disable": "error",
+    "unicorn/no-array-sort": [
+      "error",
+      { "allowAfterSpread": true, "allowExpressionStatement": false }
+    ],
+    "unicorn/no-useless-error-capture-stack-trace": "error",
+    "unicorn/prefer-node-protocol": "error"
+  },
+  "ignorePatterns": [".turbo/**", "coverage/**", "dist/**", "node_modules/**", "*.tsbuildinfo"],
+  "overrides": [{ "files": ["**/*.{js,mjs,cjs}"], "rules": { "eslint/no-undef": "error" } }]
 }


### PR DESCRIPTION
## Summary

- Align the API Oxlint policy with the reviewed web harness: maximize high-signal correctness, type-safety, async, mutation, module-boundary, and Node runtime checks without using numeric proxies.
- Keep the policy compact and upgrade-aware by declaring the complete plugin inventory, enabling stable categories, and listing only category exceptions or targeted/configured rules.
- Keep the change configuration-only; application behavior and public APIs are unchanged.

## Review checklist

- [x] Audit the installed Oxlint 1.75.0 schema and the immutable [`apps_v1.75.0`](https://github.com/oxc-project/oxc/tree/83abe3b49c0913b1a984a7eec5e433a59fd76eae) source snapshot.
- [x] Compare the API policy with the merged web harness policy from #20.
- [x] Compare stable categories plus exceptions against direct rule enumeration using the registered 1.75.0 rule metadata.
- [x] Keep all stable `correctness`, `suspicious`, `pedantic`, `perf`, and `style` categories at error severity.
- [x] Keep type-aware linting, TypeScript diagnostics, warning denial, and unused-disable reporting enabled.
- [x] Exclude numeric/count-based proxies and formatter-owned ordering rules.
- [x] Preserve backend patterns with explicit Node and Hono boundary exceptions instead of broad rule-family opt-outs.
- [x] Normalize the configuration with a one-off codemod and verify effective-config equivalence and formatter-round-trip idempotence.
- [x] Validate both the real workspace and temporary negative policy probes.

## Changes

- Keep the complete plugin list explicit because setting `plugins` replaces Oxlint's base plugin set; plugins provide rules while categories select their default severity.
- Express the global policy in review order: stable category baseline, category `off` exceptions, targeted or option-configured rules, then file-specific overrides.
- Add a JavaScript-only `eslint/no-undef` override so JavaScript configuration files receive the undefined-global protection that TypeScript already provides for TypeScript files.
- Add targeted `eslint/no-proto` enforcement and keep the existing no-parameter-mutation, no-cycle, Node path, Node protocol, non-null assertion, explicit-`any`, unsafe-type, and side-effect import boundaries.
- Restore the default `typescript/no-misused-promises` checks for conditionals, spreads, and void-return callbacks by removing the previous weakened options.
- Continue rejecting floated Promises hidden behind `void`, in-place array sorting, incomplete switches, non-readonly parameters outside the Node/Hono allowlist, and implicit boolean coercion.
- Disable all active count-based proxies: identifier length, class/file/function size, nesting depth, callback depth, parameter count, statement count, dependency count, nested-call count, and magic-number checks. The restriction-only cyclomatic complexity rule is no longer opted in.
- Delegate import/key/variable ordering to Oxfmt and allow capitalization and underscore naming patterns that may be required by framework or external API contracts.
- Remove redundant declarations and default-valued options already enforced by enabled categories, while keeping intentional diagnostic-ownership opt-outs.
- Remove the individually enabled `typescript/no-unnecessary-condition` nursery rule because backend runtime guards may intentionally validate values more defensively than their static types imply.

## Policy decisions

- **Configuration model:** use stable categories plus explicit exceptions. The same TypeScript policy would require 396 active rule entries if directly enumerated, versus 5 category entries and 69 explicit exception/addition entries. Category selection also makes newly stabilized rules visible during dependency upgrades.
- **Restriction and nursery categories:** do not enable either category wholesale. Adopt only rules with a concrete repository invariant and an actionable remediation. `eslint/no-undef` is the sole targeted nursery rule and applies only to JavaScript-family files.
- **Numeric limits:** keep numeric size, depth, dependency, and complexity thresholds disabled. They are weak architectural proxies and can force pattern changes without demonstrating a correctness problem.
- **Backend runtime behavior:** keep `node/no-sync`, Promise correctness, module-cycle detection, readonly parameter contracts, and exhaustive switches enabled because they guard observable runtime or API-boundary behavior rather than arbitrary counts.
- **JSDoc:** keep the plugin disabled. This API is an application rather than a published library, and TypeScript owns type signatures. Revisit minimal validation if generated API documentation or a public package is introduced.
- **Tests:** do not enable a test plugin until the API package has a configured test runner and filename convention.

## Impact

- The effective API harness keeps 396 rules at error severity and 48 intentional opt-outs for TypeScript sources.
- The organization-only codemod does not change the effective rule map.
- Promise misuse and JavaScript undefined globals receive stronger coverage.
- Numeric growth alone no longer fails linting.
- No runtime source, dependency, or public API changes are included.

## Verification

- `pnpm format:check`
- `pnpm lint` — API and web completed with 0 warnings and 0 errors.
- `pnpm typecheck`
- `pnpm build`
- Installed-rule metadata assertion — confirmed 5 stable categories, 48 category exceptions, 21 targeted/configured rules, and no redundant explicit entries.
- Codemod equivalence — byte-compared `oxlint --print-config` before and after the transformation and confirmed an identical effective configuration.
- Codemod idempotence — repeated codemod and Oxfmt round trips produced the same configuration hash.
- Effective-config policy assertion — confirmed all 11 active count-based rules are disabled, targeted harness rules are enforced, and wholesale `restriction`/`nursery` categories remain disabled.
- Temporary negative probes — confirmed expected diagnostics for `typescript/no-floating-promises`, `typescript/no-misused-promises`, `typescript/strict-void-return`, `unicorn/no-array-sort`, `eslint/no-proto`, and JavaScript `eslint/no-undef`; probes were removed after verification.
- API tests: not run because the API package does not define a test script.
