### PR TITLE
build: run repository toolchains through Nodeup

### DIFF
--- a/.github/actions/setup-nodeup/action.yml
+++ b/.github/actions/setup-nodeup/action.yml
@@ -9,9 +9,11 @@ runs:
       with:
         tool: nodeup@0.2.0
 
-    - name: Configure repository toolchain
+    - run: echo "$HOME/.local/bin" >> "$GITHUB_PATH"
       shell: bash
-      run: >-
-        echo "$HOME/.local/bin" >> "$GITHUB_PATH" &&
-        nodeup override set "$(<.node-version)" &&
-        nodeup shim setup
+
+    - run: nodeup override set "$(<.node-version)"
+      shell: bash
+
+    - run: nodeup shim setup
+      shell: bash

--- a/.github/actions/setup-nodeup/action.yml
+++ b/.github/actions/setup-nodeup/action.yml
@@ -11,7 +11,7 @@ runs:
 
     - name: Configure repository toolchain
       shell: bash
-      run: |
-        echo "$HOME/.local/bin" >> "$GITHUB_PATH"
-        nodeup override set "$(<.node-version)"
+      run: >-
+        echo "$HOME/.local/bin" >> "$GITHUB_PATH" &&
+        nodeup override set "$(<.node-version)" &&
         nodeup shim setup

--- a/.github/actions/setup-nodeup/action.yml
+++ b/.github/actions/setup-nodeup/action.yml
@@ -11,8 +11,6 @@ runs:
 
     - name: Configure repository toolchain
       shell: bash
-      env:
-        NODEUP_SHIM_DIR: ${{ runner.temp }}/nodeup-shims
       run: |
-        echo "$NODEUP_SHIM_DIR" >> "$GITHUB_PATH"
+        echo "$HOME/.local/bin" >> "$GITHUB_PATH"
         ./scripts/setup-nodeup.sh

--- a/.github/actions/setup-nodeup/action.yml
+++ b/.github/actions/setup-nodeup/action.yml
@@ -1,0 +1,18 @@
+name: Set up Nodeup
+description: Install and configure the repository toolchain through Nodeup
+
+runs:
+  using: composite
+  steps:
+    - name: Install Nodeup
+      uses: taiki-e/install-action@6cd13508893c0e7eab5f273c2575d3859bd7229a # v2.86.6
+      with:
+        tool: nodeup@0.2.0
+
+    - name: Configure repository toolchain
+      shell: bash
+      env:
+        NODEUP_SHIM_DIR: ${{ runner.temp }}/nodeup-shims
+      run: |
+        echo "$NODEUP_SHIM_DIR" >> "$GITHUB_PATH"
+        ./scripts/setup-nodeup.sh

--- a/.github/actions/setup-nodeup/action.yml
+++ b/.github/actions/setup-nodeup/action.yml
@@ -9,11 +9,9 @@ runs:
       with:
         tool: nodeup@0.2.0
 
-    - run: echo "$HOME/.local/bin" >> "$GITHUB_PATH"
+    - name: Configure repository toolchain
       shell: bash
-
-    - run: nodeup override set "$(<.node-version)"
-      shell: bash
-
-    - run: nodeup shim setup
-      shell: bash
+      run: |
+        echo "$HOME/.local/bin" >> "$GITHUB_PATH"
+        nodeup override set "$(<.node-version)"
+        nodeup shim setup

--- a/.github/actions/setup-nodeup/action.yml
+++ b/.github/actions/setup-nodeup/action.yml
@@ -13,4 +13,5 @@ runs:
       shell: bash
       run: |
         echo "$HOME/.local/bin" >> "$GITHUB_PATH"
-        ./scripts/setup-nodeup.sh
+        nodeup override set "$(<.node-version)"
+        nodeup shim setup

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -29,23 +29,8 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: Set up pnpm
-        uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
-
-      - name: Set up Node.js
-        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
-        with:
-          node-version-file: .node-version
-          package-manager-cache: false
-
-      - name: Verify runtime versions
-        run: |
-          runtime_node_expected="$(tr -d '\n' < .node-version)"
-          runtime_node_engine="$(node -p "require('./package.json').engines.node.slice(1)")"
-          runtime_pnpm_expected="$(node -p "require('./package.json').packageManager.split('@')[1].split('+')[0]")"
-          test "$(node --version)" = "v${runtime_node_expected}"
-          test "${runtime_node_engine}" = "${runtime_node_expected}"
-          test "$(pnpm --version)" = "${runtime_pnpm_expected}"
+      - name: Set up Nodeup
+        uses: ./.github/actions/setup-nodeup
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
@@ -80,14 +65,8 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: Set up pnpm
-        uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
-
-      - name: Set up Node.js
-        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
-        with:
-          node-version-file: .node-version
-          package-manager-cache: false
+      - name: Set up Nodeup
+        uses: ./.github/actions/setup-nodeup
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile

--- a/README.ko.md
+++ b/README.ko.md
@@ -18,17 +18,25 @@ Next.js 프론트엔드와 Hono API로 구성한 TypeScript 모노레포
 
 ## 요구사항
 
-- Node.js 24 LTS (`24.18.1` 이상인 24.x 버전)
-- pnpm `11.18.0`
+- 전역으로 설치한 [Nodeup](https://nodeup.delino.io/installation)
+- `.node-version`에 고정된 Node.js
+- `package.json`에 고정된 pnpm
 - Docker Desktop 또는 Docker Compose v2를 지원하는 Docker Engine
   (로컬 오브젝트 스토리지를 사용할 때만 필요)
 
 ## 시작하기
 
+Nodeup을 설치하고 shim 경로를 `PATH`에 추가한 뒤, clone 또는 worktree마다
+저장소 설정을 한 번 실행합니다.
+
 ```bash
+./scripts/setup-nodeup.sh
 pnpm install
 pnpm dev
 ```
+
+Nodeup은 절대 경로를 기준으로 directory override를 저장하므로, clone이나
+worktree를 새로 만들면 설정을 다시 실행해야 합니다.
 
 Garage는 선택 사항이며 애플리케이션과 별도로 실행됩니다. 오브젝트
 스토리지를 사용하는 작업에서는 먼저 Garage를 시작합니다.

--- a/README.ko.md
+++ b/README.ko.md
@@ -30,7 +30,8 @@ Nodeup을 설치하고 shim 경로를 `PATH`에 추가한 뒤, clone 또는 work
 저장소 설정을 한 번 실행합니다.
 
 ```bash
-./scripts/setup-nodeup.sh
+nodeup override set "$(<.node-version)"
+nodeup shim setup
 pnpm install
 pnpm dev
 ```

--- a/README.md
+++ b/README.md
@@ -30,7 +30,8 @@ Install Nodeup and add its shim directory to `PATH`, then run the repository
 setup once for each clone or worktree:
 
 ```bash
-./scripts/setup-nodeup.sh
+nodeup override set "$(<.node-version)"
+nodeup shim setup
 pnpm install
 pnpm dev
 ```

--- a/README.md
+++ b/README.md
@@ -18,17 +18,25 @@ API, managed with pnpm workspaces and Turborepo.
 
 ## Requirements
 
-- Node.js 24 LTS (`24.18.1` or newer within the 24.x line)
-- pnpm `11.18.0`
+- [Nodeup](https://nodeup.delino.io/installation), installed globally
+- Node.js, pinned in `.node-version`
+- pnpm, pinned in `package.json`
 - Docker Desktop or Docker Engine with Docker Compose v2 (required only for
   local object storage)
 
 ## Getting started
 
+Install Nodeup and add its shim directory to `PATH`, then run the repository
+setup once for each clone or worktree:
+
 ```bash
+./scripts/setup-nodeup.sh
 pnpm install
 pnpm dev
 ```
+
+Nodeup stores directory overrides by absolute path, so each clone or worktree
+needs its own setup run.
 
 Garage is optional and runs separately from the applications. Start it first
 when working with object storage:

--- a/scripts/setup-nodeup.sh
+++ b/scripts/setup-nodeup.sh
@@ -1,6 +1,0 @@
-#!/usr/bin/env bash
-
-set -euo pipefail
-
-nodeup override set "$(<.node-version)"
-nodeup shim setup

--- a/scripts/setup-nodeup.sh
+++ b/scripts/setup-nodeup.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+node_version="$(<.node-version)"
+
+nodeup override set "$node_version"
+nodeup shim setup
+
+node --version
+pnpm --version

--- a/scripts/setup-nodeup.sh
+++ b/scripts/setup-nodeup.sh
@@ -2,21 +2,5 @@
 
 set -euo pipefail
 
-node_version="$(<.node-version)"
-shim_dir="${NODEUP_SHIM_DIR:-$HOME/.local/bin}"
-
-nodeup override set "$node_version"
-nodeup shim setup --dir "$shim_dir"
-
-export PATH="$shim_dir:$PATH"
-
-node_engine="$(node -p "require('./package.json').engines.node")"
-pnpm_version="$(node -p "require('./package.json').packageManager.split('@')[1].split('+')[0]")"
-actual_node_version="$(node --version)"
-actual_pnpm_version="$(pnpm --version)"
-
-test "$node_engine" = "^$node_version"
-test "$actual_node_version" = "v$node_version"
-test "$actual_pnpm_version" = "$pnpm_version"
-
-printf '%s\n' "$actual_node_version" "$actual_pnpm_version"
+nodeup override set "$(<.node-version)"
+nodeup shim setup

--- a/scripts/setup-nodeup.sh
+++ b/scripts/setup-nodeup.sh
@@ -3,9 +3,20 @@
 set -euo pipefail
 
 node_version="$(<.node-version)"
+shim_dir="${NODEUP_SHIM_DIR:-$HOME/.local/bin}"
 
 nodeup override set "$node_version"
-nodeup shim setup
+nodeup shim setup --dir "$shim_dir"
 
-node --version
-pnpm --version
+export PATH="$shim_dir:$PATH"
+
+node_engine="$(node -p "require('./package.json').engines.node")"
+pnpm_version="$(node -p "require('./package.json').packageManager.split('@')[1].split('+')[0]")"
+actual_node_version="$(node --version)"
+actual_pnpm_version="$(pnpm --version)"
+
+test "$node_engine" = "^$node_version"
+test "$actual_node_version" = "v$node_version"
+test "$actual_pnpm_version" = "$pnpm_version"
+
+printf '%s\n' "$actual_node_version" "$actual_pnpm_version"


### PR DESCRIPTION
## Summary

- configure the root Node.js and pnpm toolchain through Nodeup for local worktrees and every CI job while keeping `.node-version` as the shared runtime pin

## Changes

- document the two native Nodeup setup commands for local clones and worktrees in English and Korean
- add a reusable composite action that installs Nodeup `0.2.0`, exposes its default shim directory, and runs the same commands directly
- pin `taiki-e/install-action` to commit digest `6cd13508893c0e7eab5f273c2575d3859bd7229a` (`v2.86.6`)
- replace `actions/setup-node` and `pnpm/action-setup` with the shared Nodeup action in the quality and end-to-end jobs

## Verification

- `nodeup override set "$(<.node-version)"` — passed
- `nodeup shim setup` — passed with Node.js `v24.18.1` and pnpm `11.18.0`
- YAML parsing for the composite action — passed
- `git diff --check origin/main...HEAD` — passed
- GitHub Actions `Quality` — passed
- GitHub Actions `End-to-end` — passed

## Notes

- supersedes #19 with the native Nodeup commands only; no repository wrapper script is maintained
